### PR TITLE
Fixed code execution bug in jrnl

### DIFF
--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -114,7 +114,7 @@ def verify_config_colors(config):
 def load_config(config_path):
     """Tries to load a config file from YAML."""
     with open(config_path) as f:
-        return yaml.load(f, Loader=yaml.FullLoader)
+        return yaml.load(f, Loader=yaml.SafeLoader)
 
 
 def is_config_json(config_path):


### PR DESCRIPTION
### 📊 Metadata *

Insecure YAML desearilization
#### Bounty URL:  https://www.huntr.dev/bounties/1-pip-jrnl/

### ⚙️ Description *

`jrnl` is a simple journal application for the command line., which is vulnerable to Arbitary Code Execution.

### 💻 Technical Description *

Vulnerable to YAML deserialization attack caused by unsafe loading.

### 🐛 Proof of Concept (PoC) *

```
pip install jrnl
```

`python3 exp.py`
```python3
import os
#os.sysem('pip3 install jrnl')
from jrnl import config
payload = """cmd: !!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
open('config.yml','w+').write(payload)
config.load_config('config.yml')
```


### 🔥 Proof of Fix (PoF) *

Used a more safer loader(SafeLoader) instead of `FullLoader`.


Issue is fixed, and hence no code is executed.

### 👍 User Acceptance Testing (UAT)

All Ok, No breaking changes introduced.  :)